### PR TITLE
refactor: ditching lazy_static with once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,6 @@ name = "postcss"
 version = "0.0.1"
 dependencies = [
  "criterion",
- "lazy_static",
  "memchr",
  "once_cell",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 keywords = ["css", "syntax", "postcss", "parser", "ast"]
 
 [dependencies]
-lazy_static = "1"
 memchr = "2.4"
 once_cell = "1.8.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,7 +1,7 @@
 use crate::ref_ring::RefRing;
-use lazy_static::lazy_static;
 use memchr::memchr;
 use memchr::memmem::Finder;
+use once_cell::sync::Lazy;
 use std::cell::RefCell;
 use std::clone::Clone;
 use std::cmp::PartialEq;
@@ -29,9 +29,7 @@ const AT: char = '@';
 
 const MAX_BUFFER: usize = 102400;
 
-lazy_static! {
-  static ref FINDER_END_OF_COMMENT: Finder<'static> = Finder::new("*/");
-}
+static FINDER_END_OF_COMMENT: Lazy<Finder<'static>> = Lazy::new(|| Finder::new("*/"));
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TokenType {


### PR DESCRIPTION
No more macros for defining global static variables

Signed-off-by: CGQAQ <m.jason.liu@outlook.com>